### PR TITLE
Remove use of deprecated `aes_string`

### DIFF
--- a/vignettes/GeomxTools_RNA-NGS_Analysis.Rmd
+++ b/vignettes/GeomxTools_RNA-NGS_Analysis.Rmd
@@ -372,8 +372,8 @@ QC_histogram <- function(assay_data = NULL,
                          thr = NULL,
                          scale_trans = NULL) {
     plt <- ggplot(assay_data,
-                  aes_string(x = paste0("unlist(`", annotation, "`)"),
-                             fill = fill_by)) +
+                  aes(x = unlist(.data[[annotation]]),
+                             fill = .data[[fill_by]])) +
         geom_histogram(bins = 50) +
         geom_vline(xintercept = thr, lty = "dashed", color = "black") +
         theme_bw() + guides(fill = "none") +


### PR DESCRIPTION
`aes_string` was deprecated in ggplot2 3.0.0, so this currently produces a warning related to this when run.

I updated the code to use tidy evaluation with `aes()` which avoids this.