### PR TITLE
fix typo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: GeoMxWorkflows
 Title: GeoMx Digital Spatial Profiler (DSP) data analysis workflows
 Description: Workflows for use with NanoString Technologies GeoMx Technology.  Package provides bioconductor focused workflows for leveraging existing packages (e.g. GeomxTools) to process, QC, and analyze the data.
-Version: 1.9.1
+Version: 1.13.1
 Encoding: UTF-8
 Authors@R: c(person("Maddy", "Griswold", email = "mgriswold@nanostring.com", role = c("cre", "aut")),
              person("Jason", "Reeves", role = c("aut")), 

--- a/vignettes/GeomxTools_RNA-NGS_Analysis.Rmd
+++ b/vignettes/GeomxTools_RNA-NGS_Analysis.Rmd
@@ -284,7 +284,7 @@ ROI/AOI segment.
 
 Every ROI/AOI segment will be tested for:
 
-* Raw sequencing reads: segments with >1000 raw reads are removed.
+* Raw sequencing reads: segments with <1000 raw reads are removed.
 * % Aligned,% Trimmed, or % Stitched sequencing reads: segments below ~80% for 
 one or more of these QC parameters are removed.
 * % Sequencing saturation ([1-deduplicated reads/aligned reads]%): segments 


### PR DESCRIPTION
Fix typo in QC description. Confirmed fix was just in description not in [actual code](https://github.com/Nanostring-Biostats/GeomxTools/blob/51df1b5c45405f6e6ab5fb6313963a3996b7e2ae/R/NanoStringGeoMxSet-qc.R#L83). 

ADO issue #228450

Bioc version is 1.13.0 so bumping subminor. 